### PR TITLE
Create ~/Library/LaunchAgents during install if necessary

### DIFF
--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 if [ "$(uname)" == "Darwin" ]; then
+	mkdir -p ~/Library/LaunchAgents
 	cp kong.plist ~/Library/LaunchAgents/com.github.konradreiche.kong.plist
 	launchctl unload -w ~/Library/LaunchAgents/com.github.konradreiche.kong.plist || true
 	launchctl load -w ~/Library/LaunchAgents/com.github.konradreiche.kong.plist


### PR DESCRIPTION
While running `make install`, I encountered an error that was caused by not having a `~/Library/LaunchAgents` directory before beginning. To prevent this, the `./scripts/reload.sh` that is called along this path could be updated to pre-emptively create the directory if it is not already present.
